### PR TITLE
Update start_mac.command (now compatible with mac)

### DIFF
--- a/start_mac.command
+++ b/start_mac.command
@@ -1,2 +1,2 @@
-node index.js
+node server.js
 pause


### PR DESCRIPTION
so like it will ask to execute index.js(which doesnt exist) so if you swap the .command file to a server.js just go to home terminal cd (file directory) and do ./start_mac.command the bots will run on mac instead of displaying a thwo error

so do the same steps with tampermonkey and everything, except do the extra steps stated above